### PR TITLE
feat(theming): styled-components theme foundation + light/dark toggle (Group 2)

### DIFF
--- a/openspec/changes/redesign-ui-styled-components/tasks.md
+++ b/openspec/changes/redesign-ui-styled-components/tasks.md
@@ -7,19 +7,19 @@
 
 ## 2. Theme foundation (palette, slice, provider, persistence)  <!-- judgement-heavy -->
 
-- [ ] 2.1 Create `app/theme/palettes.ts` exporting typed `dark` and `light` `DefaultTheme` objects sharing one structure (colors: background/gradient, accent, glass bg/border, text, statusDot; radii; fonts sans/mono); dark values ported from the design, light derived from the same hues
-- [ ] 2.2 Verify WCAG AA contrast (≥4.5:1 body text, ≥3:1 large text/accent-on-background) for both palettes' text and accent colors; adjust the light-palette tokens until they pass and record the checked pairs/ratios in a comment in `palettes.ts`
-- [ ] 2.3 Create `app/theme/styled.d.ts` augmenting `styled-components`' `DefaultTheme` with the palette shape (no `any`)
-- [ ] 2.4 Create `app/theme/GlobalStyle.ts` (`createGlobalStyle`) providing the reset + body background gradient + base font + link colors from `theme` tokens (replacing what `normalize.css`/`common.scss` did)
-- [ ] 2.5 Create `features/theming/themeSlice.ts`: `ThemeState = { mode: 'dark' | 'light' }`, single `toggleTheme` reducer, and a `selectThemeMode` selector
-- [ ] 2.6 Add a `loadThemeMode()` helper (beside `loadHistory` in `app/store.ts`) resolving: persisted `theme-mode` in `localStorage` → OS preference via `matchMedia` **only when `typeof window !== 'undefined' && typeof window.matchMedia === 'function'`** → `'dark'`; register the `theme` slice and pass the resolved mode as `preloadedState`
-- [ ] 2.7 Add a `createListenerMiddleware` rule in `app/listenerMiddleware.ts` that persists `mode` to the `theme-mode` key on `toggleTheme` (leave the search-history rule untouched)
-- [ ] 2.8 Add a `window.matchMedia` mock to `src/setupTests.ts` so default-resolution branches are exercisable
-- [ ] 2.9 Create the connected `features/theming/ThemeToggle` component: reads `mode` via `useAppSelector`, dispatches `toggleTheme` via `useAppDispatch`, renders an accessible button (`aria-label`, `aria-pressed`) with a sun/moon affordance
-- [ ] 2.10 Add a `ThemedApp` wrapper **inside `App.tsx`'s `<Provider>`** that selects `mode` and wraps the `Header`/`SearchPage` tree in `<ThemeProvider theme={palettes[mode]}>` + `<GlobalStyle/>`; leave `src/index.tsx` unchanged
-- [ ] 2.11 Add tests: `themeSlice` (initial state, `toggleTheme` both directions), `loadThemeMode` (persisted wins, OS-dark, OS-light, no-`matchMedia` fallback), the persistence listener (writes `theme-mode`, leaves history untouched), and `ThemeToggle` (renders accessible control, dispatches on click, reflects state)
-- [ ] 2.12 Add a theme-application test: render a token-dependent styled component through `ThemedApp`/`ThemeProvider` with `mode: 'dark'` and with `mode: 'light'`, asserting the resolved palette differs (e.g. a computed color/`data-` token), so the "Theme selection" spec scenarios are exercised — not just the slice
-- [ ] 2.13 Verify: `yarn typecheck && yarn lint && yarn test:coverage` green (90% floor holds)
+- [x] 2.1 Create `app/theme/palettes.ts` exporting typed `dark` and `light` `DefaultTheme` objects sharing one structure (colors: background/gradient, accent, glass bg/border, text, statusDot; radii; fonts sans/mono); dark values ported from the design, light derived from the same hues
+- [x] 2.2 Verify WCAG AA contrast (≥4.5:1 body text, ≥3:1 large text/accent-on-background) for both palettes' text and accent colors; adjust the light-palette tokens until they pass and record the checked pairs/ratios in a comment in `palettes.ts`
+- [x] 2.3 Create `app/theme/styled.d.ts` augmenting `styled-components`' `DefaultTheme` with the palette shape (no `any`)
+- [x] 2.4 Create `app/theme/GlobalStyle.ts` (`createGlobalStyle`) providing the reset + body background gradient + base font + link colors from `theme` tokens (replacing what `normalize.css`/`common.scss` did)
+- [x] 2.5 Create `features/theming/themeSlice.ts`: `ThemeState = { mode: 'dark' | 'light' }`, single `toggleTheme` reducer, and a `selectThemeMode` selector
+- [x] 2.6 Add a `loadThemeMode()` helper (beside `loadHistory` in `app/store.ts`) resolving: persisted `theme-mode` in `localStorage` → OS preference via `matchMedia` **only when `typeof window !== 'undefined' && typeof window.matchMedia === 'function'`** → `'dark'`; register the `theme` slice and pass the resolved mode as `preloadedState`
+- [x] 2.7 Add a `createListenerMiddleware` rule in `app/listenerMiddleware.ts` that persists `mode` to the `theme-mode` key on `toggleTheme` (leave the search-history rule untouched)
+- [x] 2.8 Add a `window.matchMedia` mock to `src/setupTests.ts` so default-resolution branches are exercisable
+- [x] 2.9 Create the connected `features/theming/ThemeToggle` component: reads `mode` via `useAppSelector`, dispatches `toggleTheme` via `useAppDispatch`, renders an accessible button (`aria-label`, `aria-pressed`) with a sun/moon affordance
+- [x] 2.10 Add a `ThemedApp` wrapper **inside `App.tsx`'s `<Provider>`** that selects `mode` and wraps the `Header`/`SearchPage` tree in `<ThemeProvider theme={palettes[mode]}>` + `<GlobalStyle/>`; leave `src/index.tsx` unchanged
+- [x] 2.11 Add tests: `themeSlice` (initial state, `toggleTheme` both directions), `loadThemeMode` (persisted wins, OS-dark, OS-light, no-`matchMedia` fallback), the persistence listener (writes `theme-mode`, leaves history untouched), and `ThemeToggle` (renders accessible control, dispatches on click, reflects state)
+- [x] 2.12 Add a theme-application test: render a token-dependent styled component through `ThemedApp`/`ThemeProvider` with `mode: 'dark'` and with `mode: 'light'`, asserting the resolved palette differs (e.g. a computed color/`data-` token), so the "Theme selection" spec scenarios are exercised — not just the slice
+- [x] 2.13 Verify: `yarn typecheck && yarn lint && yarn test:coverage` green (90% floor holds)
 
 ## 3. Migrate leaf components (Repository, Loader)  <!-- isolated -->
 

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import type { ComponentProps } from 'react';
+import type { DefaultTheme } from 'styled-components';
+import App, { ThemedApp } from './App';
+import store, { setupStore } from 'app/store';
+import { palettes, type ThemeMode } from 'app/theme/palettes';
+
+// styled-components injects styles into a detached CSSOM sheet under jsdom, so
+// the applied palette isn't readable from the DOM. Instead, wrap the real
+// ThemeProvider to capture the theme ThemedApp hands it — this is the exact
+// store→palette link (theme={palettes[mode]}) that no other test covers, and a
+// regression to a hardcoded palette would be caught here. The real provider
+// still renders, so GlobalStyle and the tree below get proper theme context.
+const { capturedThemes } = vi.hoisted(() => ({
+  capturedThemes: [] as DefaultTheme[],
+}));
+
+vi.mock('styled-components', async importOriginal => {
+  const actual = await importOriginal<typeof import('styled-components')>();
+  return {
+    ...actual,
+    ThemeProvider: (props: ComponentProps<typeof actual.ThemeProvider>) => {
+      if (props.theme) capturedThemes.push(props.theme as DefaultTheme);
+      return <actual.ThemeProvider {...props} />;
+    },
+  };
+});
+
+const renderThemedApp = (mode: ThemeMode) =>
+  render(
+    <Provider
+      store={setupStore({
+        theme: { mode },
+        searchHistory: { entries: [], openId: null },
+      })}
+    >
+      <ThemedApp />
+    </Provider>,
+  );
+
+beforeEach(() => {
+  capturedThemes.length = 0;
+});
+
+describe('ThemedApp', () => {
+  it('renders the app tree and selects the dark palette from the store mode', () => {
+    renderThemedApp('dark');
+
+    // The app actually rendered (Form input present), not just the provider.
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(capturedThemes).toContain(palettes.dark);
+    expect(capturedThemes).not.toContain(palettes.light);
+  });
+
+  it('selects the light palette when the store mode is light', () => {
+    renderThemedApp('light');
+
+    expect(capturedThemes).toContain(palettes.light);
+    expect(capturedThemes).not.toContain(palettes.dark);
+  });
+
+  it('mounts the default App with the singleton store and a resolved palette', () => {
+    render(<App />);
+
+    // The default export wires the real singleton store; it renders the tree and
+    // hands ThemeProvider a palette resolved from the store's hydrated mode.
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(capturedThemes).toContain(palettes[store.getState().theme.mode]);
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,16 +1,38 @@
 import React from 'react';
+// normalize.css + common.scss stay until Group 6: unmigrated components still
+// use the global .container/.row/.warning utility classes until they're ported.
 import 'normalize.css';
 import 'styles/common.scss';
 import { Provider } from 'react-redux';
+import { ThemeProvider } from 'styled-components';
 import store from 'app/store';
+import { useAppSelector } from 'app/hooks';
+import { selectThemeMode } from 'features/theming/themeSlice';
+import { palettes } from 'app/theme/palettes';
+import { GlobalStyle } from 'app/theme/GlobalStyle';
 import SearchPage from 'pages/SearchPage';
 import Header from 'components/Header';
+
+// Sits inside <Provider> so it can read the theme mode from the store, then
+// feeds the active palette to every styled component and mounts the themed
+// global reset. index.tsx stays unchanged (design D2). Exported so the
+// store→provider wiring is testable against a preloaded mode.
+export const ThemedApp: React.FC = () => {
+  const mode = useAppSelector(selectThemeMode);
+
+  return (
+    <ThemeProvider theme={palettes[mode]}>
+      <GlobalStyle />
+      <Header />
+      <SearchPage />
+    </ThemeProvider>
+  );
+};
 
 const App: React.FC = () => {
   return (
     <Provider store={store}>
-      <Header />
-      <SearchPage />
+      <ThemedApp />
     </Provider>
   );
 };

--- a/src/app/listenerMiddleware.test.ts
+++ b/src/app/listenerMiddleware.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { setupStore } from './store';
 import { addSession, toggleSession } from 'features/searchHistory/searchHistorySlice';
+import { toggleTheme } from 'features/theming/themeSlice';
 
 beforeEach(() => {
   localStorage.clear();
@@ -27,5 +28,26 @@ describe('history persistence (listenerMiddleware)', () => {
     store.dispatch(toggleSession(1));
 
     expect(localStorage.getItem('sessions')).toBeNull();
+  });
+});
+
+describe('theme persistence (listenerMiddleware)', () => {
+  it('writes the mode to its own theme-mode key on toggle', () => {
+    const store = setupStore({ theme: { mode: 'dark' } });
+
+    store.dispatch(toggleTheme());
+
+    expect(localStorage.getItem('theme-mode')).toBe('light');
+  });
+
+  it('leaves persisted search history untouched when the theme toggles', () => {
+    const store = setupStore({ theme: { mode: 'dark' } });
+    store.dispatch(addSession('react'));
+    const historyBefore = localStorage.getItem('sessions');
+
+    store.dispatch(toggleTheme());
+
+    expect(localStorage.getItem('sessions')).toBe(historyBefore);
+    expect(localStorage.getItem('theme-mode')).toBe('light');
   });
 });

--- a/src/app/listenerMiddleware.ts
+++ b/src/app/listenerMiddleware.ts
@@ -1,5 +1,6 @@
 import { createListenerMiddleware } from '@reduxjs/toolkit';
 import { addSession } from 'features/searchHistory/searchHistorySlice';
+import { toggleTheme } from 'features/theming/themeSlice';
 import type { RootState } from './store';
 
 export const listenerMiddleware = createListenerMiddleware();
@@ -12,5 +13,16 @@ listenerMiddleware.startListening({
   effect: (_action, listenerApi) => {
     const { entries } = (listenerApi.getState() as RootState).searchHistory;
     localStorage.setItem('sessions', JSON.stringify(entries));
+  },
+});
+
+// Persist the theme choice under its own key on every toggle, independent of
+// the search-history rule above (design D2). The key is distinct so theme
+// persistence never disturbs stored search history.
+listenerMiddleware.startListening({
+  actionCreator: toggleTheme,
+  effect: (_action, listenerApi) => {
+    const { mode } = (listenerApi.getState() as RootState).theme;
+    localStorage.setItem('theme-mode', mode);
   },
 });

--- a/src/app/store.test.ts
+++ b/src/app/store.test.ts
@@ -1,8 +1,55 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { loadHistory, setupStore } from './store';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { loadHistory, loadThemeMode, setupStore } from './store';
+import { createMatchMedia } from 'testUtils';
 
 beforeEach(() => {
   localStorage.clear();
+});
+
+describe('loadThemeMode', () => {
+  const original = window.matchMedia;
+  // setupTests installs a default (matches: false) stub; restore it afterwards
+  // so nothing leaks into later tests.
+  afterEach(() => {
+    window.matchMedia = original;
+  });
+
+  it('prefers a persisted choice over the OS preference', () => {
+    localStorage.setItem('theme-mode', 'light');
+    window.matchMedia = createMatchMedia(false); // OS reports dark
+    expect(loadThemeMode()).toBe('light');
+  });
+
+  it('ignores a malformed persisted value and falls through to the OS', () => {
+    // OS prefers light: proves the malformed value is rejected and the code
+    // re-checks matchMedia, rather than short-circuiting to the 'dark' default
+    // (which would pass even for a broken fallthrough).
+    localStorage.setItem('theme-mode', 'sepia');
+    window.matchMedia = createMatchMedia(true);
+    expect(loadThemeMode()).toBe('light');
+  });
+
+  it('resolves to dark when no choice is persisted and the OS prefers dark', () => {
+    window.matchMedia = createMatchMedia(false);
+    expect(loadThemeMode()).toBe('dark');
+  });
+
+  it('resolves to light when no choice is persisted and the OS prefers light', () => {
+    window.matchMedia = createMatchMedia(true);
+    expect(loadThemeMode()).toBe('light');
+  });
+
+  it('falls back to dark when matchMedia is unavailable', () => {
+    window.matchMedia = undefined as unknown as typeof window.matchMedia;
+    expect(loadThemeMode()).toBe('dark');
+  });
+
+  it('falls back to dark when matchMedia throws', () => {
+    window.matchMedia = vi.fn(() => {
+      throw new Error('blocked');
+    }) as unknown as typeof window.matchMedia;
+    expect(loadThemeMode()).toBe('dark');
+  });
 });
 
 describe('loadHistory', () => {

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -1,8 +1,39 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, combineReducers } from '@reduxjs/toolkit';
 import { ISession } from 'typings/interfaces';
 import { listenerMiddleware } from './listenerMiddleware';
 import { githubApi } from './githubApi';
 import searchHistoryReducer from 'features/searchHistory/searchHistorySlice';
+import themeReducer from 'features/theming/themeSlice';
+import type { ThemeMode } from 'app/theme/palettes';
+
+const THEME_STORAGE_KEY = 'theme-mode';
+
+// Resolve the initial theme in load order: a persisted choice wins; otherwise
+// the OS preference via matchMedia; otherwise 'dark'. matchMedia is
+// feature-detected (not just window-guarded) because this repo's jsdom test env
+// defines window but not window.matchMedia, and store.ts is eagerly imported
+// across the suite (design D2). Isolated here so browser-API access lives in one
+// place, mirroring loadHistory.
+export const loadThemeMode = (): ThemeMode => {
+  try {
+    const persisted = localStorage.getItem(THEME_STORAGE_KEY);
+    if (persisted === 'dark' || persisted === 'light') return persisted;
+
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function'
+    ) {
+      return window.matchMedia('(prefers-color-scheme: light)').matches
+        ? 'light'
+        : 'dark';
+    }
+  } catch {
+    // localStorage or matchMedia unavailable/throwing — fall back to dark, so a
+    // module-eval-time resolution can never crash the app before it renders.
+  }
+
+  return 'dark';
+};
 
 // Restore the query-key history from localStorage. Only { id, query } is read;
 // any extra fields are ignored, and a legacy pre-rework entry that stored the
@@ -30,14 +61,20 @@ export const loadHistory = (): Array<ISession> => {
   }
 };
 
-export const setupStore = (preloadedState?: {
-  searchHistory: ReturnType<typeof searchHistoryReducer>;
-}) =>
+const rootReducer = combineReducers({
+  searchHistory: searchHistoryReducer,
+  theme: themeReducer,
+  [githubApi.reducerPath]: githubApi.reducer,
+});
+
+export type RootState = ReturnType<typeof rootReducer>;
+
+// Partial<RootState> is RTK's documented preloadedState shape for a combined
+// reducer: each slice can be omitted (callers preload only what they need)
+// without forcing any reducer to accept an undefined preloaded state.
+export const setupStore = (preloadedState?: Partial<RootState>) =>
   configureStore({
-    reducer: {
-      searchHistory: searchHistoryReducer,
-      [githubApi.reducerPath]: githubApi.reducer,
-    },
+    reducer: rootReducer,
     preloadedState,
     middleware: getDefaultMiddleware =>
       getDefaultMiddleware()
@@ -46,13 +83,15 @@ export const setupStore = (preloadedState?: {
   });
 
 // Restored history starts collapsed — no query fires until the user expands an
-// entry, so a page load never triggers a search (design D3/D7).
+// entry, so a page load never triggers a search (design D3/D7). Theme mode is
+// resolved once here and injected as preloadedState, so there's no flash-then-
+// switch on load (design D2).
 const store = setupStore({
   searchHistory: { entries: loadHistory(), openId: null },
+  theme: { mode: loadThemeMode() },
 });
 
 export type AppStore = typeof store;
-export type RootState = ReturnType<AppStore['getState']>;
 export type AppDispatch = AppStore['dispatch'];
 
 export default store;

--- a/src/app/theme/GlobalStyle.test.tsx
+++ b/src/app/theme/GlobalStyle.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ServerStyleSheet, ThemeProvider } from 'styled-components';
+import { GlobalStyle } from './GlobalStyle';
+import { palettes, type ThemeMode } from './palettes';
+
+// Under jsdom, styled-components injects into a detached sheet, so GlobalStyle's
+// theme interpolations never run and its CSS isn't DOM-readable. SSR collection
+// forces those interpolations to evaluate and yields the generated CSS, so we
+// can assert the global reset/body actually consumes the active palette's tokens.
+const globalCss = (mode: ThemeMode): string => {
+  const sheet = new ServerStyleSheet();
+  try {
+    renderToStaticMarkup(
+      sheet.collectStyles(
+        <ThemeProvider theme={palettes[mode]}>
+          <GlobalStyle />
+        </ThemeProvider>,
+      ),
+    );
+    return sheet.getStyleTags();
+  } finally {
+    sheet.seal();
+  }
+};
+
+describe('GlobalStyle', () => {
+  it('applies the dark palette tokens to the global body/base styles', () => {
+    const css = globalCss('dark');
+    expect(css).toContain(palettes.dark.color.text);
+    expect(css).toContain(palettes.dark.color.accent);
+    expect(css).not.toContain(palettes.light.color.text);
+  });
+
+  it('applies the light palette tokens under the light theme', () => {
+    const css = globalCss('light');
+    expect(css).toContain(palettes.light.color.text);
+    expect(css).toContain(palettes.light.color.accent);
+    expect(css).not.toContain(palettes.dark.color.text);
+  });
+});

--- a/src/app/theme/GlobalStyle.ts
+++ b/src/app/theme/GlobalStyle.ts
@@ -1,0 +1,49 @@
+import { createGlobalStyle } from 'styled-components';
+
+// Replaces normalize.css + src/styles/common.scss: a minimal reset plus the
+// themed body background gradient, base font, and link colors — all from theme
+// tokens so both palettes flow through the single ThemeProvider (design D1).
+export const GlobalStyle = createGlobalStyle`
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  body {
+    min-width: 320px;
+    min-height: 100vh;
+    font-family: ${({ theme }) => theme.font.sans};
+    font-size: 16px;
+    line-height: 1.6;
+    color: ${({ theme }) => theme.color.text};
+    background: ${({ theme }) => theme.color.gradient} fixed;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  p {
+    margin: 0;
+  }
+
+  ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  a {
+    color: ${({ theme }) => theme.color.accent};
+    text-decoration: none;
+    transition: opacity 0.2s ease-in-out;
+  }
+
+  a:hover {
+    opacity: 0.8;
+  }
+`;

--- a/src/app/theme/palettes.ts
+++ b/src/app/theme/palettes.ts
@@ -1,0 +1,55 @@
+import type { DefaultTheme } from 'styled-components';
+
+// Single source of truth for every color/token. Dark is lifted from the approved
+// redesign (oklch-based glassmorphism); light is derived from the same hues with
+// lightness/chroma tuned for contrast on a light background (design D4).
+//
+// WCAG AA contrast, foreground-on-background (verified via OKLCH→sRGB→WCAG):
+//   DARK   text 17.51:1 · textMuted 7.93:1 · accent 9.25:1 · statusDot 9.41:1 · danger 6.26:1
+//   LIGHT  text 16.34:1 · textMuted 7.33:1 · accent 5.54:1 · statusDot 4.28:1 · danger 6.30:1
+// Body text/accent clear the ≥4.5:1 body floor; statusDot is a decorative dot,
+// held to the ≥3:1 non-text floor, which it clears in both palettes.
+
+export const dark: DefaultTheme = {
+  color: {
+    background: 'oklch(0.15 0.01 260)',
+    gradient:
+      'radial-gradient(ellipse 80% 60% at 50% -10%, oklch(0.25 0.06 280 / 0.5), transparent 70%), oklch(0.15 0.01 260)',
+    accent: 'oklch(0.78 0.15 280)',
+    glassBg: 'rgba(255, 255, 255, 0.06)',
+    glassBorder: 'rgba(255, 255, 255, 0.12)',
+    text: 'oklch(0.96 0 0)',
+    textMuted: 'oklch(0.72 0.02 260)',
+    statusDot: 'oklch(0.75 0.16 150)',
+    danger: 'oklch(0.68 0.19 25)',
+  },
+  radii: { sm: '8px', md: '12px', lg: '16px' },
+  font: {
+    sans: "'Inter', system-ui, -apple-system, sans-serif",
+    mono: "'JetBrains Mono', ui-monospace, monospace",
+  },
+};
+
+export const light: DefaultTheme = {
+  color: {
+    background: 'oklch(0.98 0.005 260)',
+    gradient:
+      'radial-gradient(ellipse 80% 60% at 50% -10%, oklch(0.85 0.05 280 / 0.5), transparent 70%), oklch(0.98 0.005 260)',
+    accent: 'oklch(0.52 0.18 280)',
+    glassBg: 'rgba(0, 0, 0, 0.04)',
+    glassBorder: 'rgba(0, 0, 0, 0.1)',
+    text: 'oklch(0.22 0.01 260)',
+    textMuted: 'oklch(0.44 0.02 260)',
+    statusDot: 'oklch(0.55 0.15 150)',
+    danger: 'oklch(0.5 0.2 25)',
+  },
+  radii: { sm: '8px', md: '12px', lg: '16px' },
+  font: {
+    sans: "'Inter', system-ui, -apple-system, sans-serif",
+    mono: "'JetBrains Mono', ui-monospace, monospace",
+  },
+};
+
+export type ThemeMode = 'dark' | 'light';
+
+export const palettes: Record<ThemeMode, DefaultTheme> = { dark, light };

--- a/src/app/theme/styled.d.ts
+++ b/src/app/theme/styled.d.ts
@@ -1,0 +1,28 @@
+import 'styled-components';
+
+// Augment styled-components' DefaultTheme so every styled component gets
+// type-checked access to theme tokens — no magic color strings (design D1).
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    color: {
+      background: string;
+      gradient: string;
+      accent: string;
+      glassBg: string;
+      glassBorder: string;
+      text: string;
+      textMuted: string;
+      statusDot: string;
+      danger: string;
+    };
+    radii: {
+      sm: string;
+      md: string;
+      lg: string;
+    };
+    font: {
+      sans: string;
+      mono: string;
+    };
+  }
+}

--- a/src/features/theming/ThemeToggle/index.test.tsx
+++ b/src/features/theming/ThemeToggle/index.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { ThemeProvider } from 'styled-components';
+import ThemeToggle from './index';
+import { setupStore, type AppStore } from 'app/store';
+import { palettes, type ThemeMode } from 'app/theme/palettes';
+
+const renderToggle = (mode: ThemeMode): AppStore => {
+  const store = setupStore({ theme: { mode } });
+  render(
+    <Provider store={store}>
+      <ThemeProvider theme={palettes[mode]}>
+        <ThemeToggle />
+      </ThemeProvider>
+    </Provider>,
+  );
+  return store;
+};
+
+describe('ThemeToggle', () => {
+  it('renders an accessible control reflecting the dark state', () => {
+    renderToggle('dark');
+
+    const button = screen.getByRole('button', {
+      name: /switch to light theme/i,
+    });
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders an accessible control reflecting the light state', () => {
+    renderToggle('light');
+
+    const button = screen.getByRole('button', {
+      name: /switch to dark theme/i,
+    });
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('dispatches a toggle and reflects the new state on click', async () => {
+    const user = userEvent.setup();
+    const store = renderToggle('dark');
+
+    await user.click(
+      screen.getByRole('button', { name: /switch to light theme/i }),
+    );
+
+    expect(store.getState().theme.mode).toBe('light');
+    expect(
+      screen.getByRole('button', { name: /switch to dark theme/i }),
+    ).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/src/features/theming/ThemeToggle/index.tsx
+++ b/src/features/theming/ThemeToggle/index.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useAppDispatch, useAppSelector } from 'app/hooks';
+import { selectThemeMode, toggleTheme } from 'features/theming/themeSlice';
+
+const ToggleButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+  color: ${({ theme }) => theme.color.text};
+  background: ${({ theme }) => theme.color.glassBg};
+  border: 1px solid ${({ theme }) => theme.color.glassBorder};
+  border-radius: ${({ theme }) => theme.radii.md};
+  transition:
+    border-color 0.2s ease-in-out,
+    opacity 0.2s ease-in-out;
+
+  &:hover {
+    border-color: ${({ theme }) => theme.color.accent};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.color.accent};
+    outline-offset: 2px;
+  }
+`;
+
+// Connected: owns no local state, reads mode from the store and dispatches the
+// single toggleTheme action (design D3). Header stays dumb by composing this.
+const ThemeToggle: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const mode = useAppSelector(selectThemeMode);
+  const isLight = mode === 'light';
+
+  return (
+    <ToggleButton
+      type="button"
+      aria-pressed={isLight}
+      aria-label={`Switch to ${isLight ? 'dark' : 'light'} theme`}
+      onClick={() => dispatch(toggleTheme())}
+    >
+      <span aria-hidden="true">{isLight ? '☀' : '🌙'}</span>
+    </ToggleButton>
+  );
+};
+
+export default ThemeToggle;

--- a/src/features/theming/themeApplication.test.tsx
+++ b/src/features/theming/themeApplication.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import styled, { ThemeProvider } from 'styled-components';
+import { palettes, type ThemeMode } from 'app/theme/palettes';
+
+// A token-dependent styled component: it surfaces the resolved accent token as a
+// data attribute (via attrs, which receives the active theme), so the palette a
+// component actually renders with is directly assertable through the provider —
+// exercising the "Dark/Light theme applied" spec scenarios, not just the slice.
+const Swatch = styled.div.attrs<{ 'data-accent'?: string }>(({ theme }) => ({
+  'data-accent': theme.color.accent,
+}))``;
+
+const renderSwatch = (mode: ThemeMode) =>
+  render(
+    <ThemeProvider theme={palettes[mode]}>
+      <Swatch data-testid="swatch" />
+    </ThemeProvider>,
+  );
+
+describe('theme application', () => {
+  it('renders the dark palette accent under the dark theme', () => {
+    renderSwatch('dark');
+    expect(screen.getByTestId('swatch')).toHaveAttribute(
+      'data-accent',
+      palettes.dark.color.accent,
+    );
+  });
+
+  it('renders the light palette accent under the light theme', () => {
+    renderSwatch('light');
+    expect(screen.getByTestId('swatch')).toHaveAttribute(
+      'data-accent',
+      palettes.light.color.accent,
+    );
+  });
+
+  it('resolves a different accent for each theme', () => {
+    expect(palettes.dark.color.accent).not.toBe(palettes.light.color.accent);
+  });
+});

--- a/src/features/theming/themeSlice.test.ts
+++ b/src/features/theming/themeSlice.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import reducer, {
+  toggleTheme,
+  selectThemeMode,
+  type ThemeState,
+} from './themeSlice';
+import type { RootState } from 'app/store';
+
+describe('themeSlice', () => {
+  it('defaults to dark mode', () => {
+    expect(reducer(undefined, { type: '@@INIT' })).toEqual({ mode: 'dark' });
+  });
+
+  it('toggles dark → light', () => {
+    const next = reducer({ mode: 'dark' }, toggleTheme());
+    expect(next).toEqual({ mode: 'light' });
+  });
+
+  it('toggles light → dark', () => {
+    const next = reducer({ mode: 'light' }, toggleTheme());
+    expect(next).toEqual({ mode: 'dark' });
+  });
+});
+
+describe('selectThemeMode', () => {
+  it('reads the mode from state', () => {
+    const state = { theme: { mode: 'light' } as ThemeState } as RootState;
+    expect(selectThemeMode(state)).toBe('light');
+  });
+});

--- a/src/features/theming/themeSlice.ts
+++ b/src/features/theming/themeSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit';
+import type { ThemeMode } from 'app/theme/palettes';
+import type { RootState } from 'app/store';
+
+export interface ThemeState {
+  mode: ThemeMode;
+}
+
+// Default is resolved at store creation by loadThemeMode() (persisted → OS → dark)
+// and injected as preloadedState; this fallback only applies if the slice is used
+// without hydration (design D2).
+const initialState: ThemeState = { mode: 'dark' };
+
+const themeSlice = createSlice({
+  name: 'theme',
+  initialState,
+  reducers: {
+    // The whole two-theme invariant lives in this one reducer, mirroring
+    // searchHistory's single-reducer toggle (design D2).
+    toggleTheme: state => {
+      state.mode = state.mode === 'dark' ? 'light' : 'dark';
+    },
+  },
+});
+
+export const { toggleTheme } = themeSlice.actions;
+
+export const selectThemeMode = (state: RootState): ThemeMode =>
+  state.theme.mode;
+
+export default themeSlice.reducer;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,15 @@
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
+import { createMatchMedia } from './testUtils';
+
+// jsdom does not implement window.matchMedia. Provide a default stub (matches:
+// false → OS-dark branch) so the eager store.ts import resolves; tests that
+// exercise the OS-light or no-matchMedia branches override/delete it locally.
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: createMatchMedia(false),
+});
 
 afterEach(cleanup);

--- a/src/testUtils.ts
+++ b/src/testUtils.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest';
+
+// Shared MediaQueryList stub: jsdom doesn't implement window.matchMedia, so both
+// setupTests.ts (default stub) and tests that drive the prefers-color-scheme
+// branch build one from here — a single mock shape, not two copies to keep in
+// sync. Every query reports the given `matches`.
+export const createMatchMedia = (matches: boolean): typeof window.matchMedia =>
+  vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;


### PR DESCRIPTION
## Group 2 — Theme foundation

Second task group of the OpenSpec change **redesign-ui-styled-components** (classified `judgement-heavy`), landing on its own branch per `.claude/docs/git-conventions.md`. Introduces the styled-components typed theme and the light/dark toggle capability; no component skins yet (Groups 3–5) and the old SCSS system stays until Group 6.

### What's in it
- **`app/theme/`** — typed `DefaultTheme` `palettes.ts` (dark ported from the design, light derived; **WCAG AA contrast verified**, ratios recorded in a comment), `styled.d.ts` augmentation (no `any`), `GlobalStyle.ts` (`createGlobalStyle` from theme tokens).
- **`features/theming/`** — `themeSlice.ts` (`toggleTheme` + `selectThemeMode`) and a connected, accessible `ThemeToggle` (`aria-label`/`aria-pressed`).
- **Store** — `loadThemeMode()` (persisted → OS via feature-detected `matchMedia` → `dark`, whole body guarded), `combineReducers` + `Partial<RootState>` preloadedState, theme hydration.
- **Persistence** — `listenerMiddleware` writes `mode` to its own `theme-mode` key; the search-history rule is untouched.
- **Root** — `ThemedApp` wrapper inside `<Provider>` mounts `ThemeProvider` + `GlobalStyle`; `index.tsx` unchanged.

### Spec coverage (`specs/ui-theming/spec.md`)
Theme selection, default resolution (persisted / OS-dark / OS-light / no-`matchMedia` / throw), toggle (a11y + both directions), and persistence (own key, history undisturbed) all have tests.

### Review gates
- **Gate 4 (code-review):** 1 PLAUSIBLE + 1 CONFIRMED → both fixed (guard whole `loadThemeMode` body; DRY the `matchMedia` mock into `testUtils.ts`).
- **Gate 5 (test-coverage):** 2 CONFIRMED → both fixed (added `ThemedApp` store→palette test + `GlobalStyle` SSR test; strengthened the malformed-persisted assertion to prove OS fallthrough).
- Gate 3 (web-qa) and Gate 6 (harness) intentionally deferred — they run only on the change's **last** group.

### Validation
`yarn typecheck` · `yarn lint` · `yarn test:coverage` all green — **59 tests, 100% statements/branches/functions/lines** (90% floor holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)