### PR TITLE
fix(deps): sync yarn.lock with package.json

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2295,7 +2295,7 @@ strip-url-auth@^1.0.0:
   resolved "https://registry.yarnpkg.com/strip-url-auth/-/strip-url-auth-1.0.1.tgz#22b0fa3a41385b33be3f331551bbb837fa0cd7ae"
   integrity sha1-IrD6OkE4WzO+PzMVUbu4N/oM164=
 
-styled-components@^6:
+styled-components@^6.4.4:
   version "6.4.4"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-6.4.4.tgz#403eb7046b9f59a170d13967d9e7d21d82e677bd"
   integrity sha512-tJk5CmKUPMDoTsZQ8m0hHInBk9HFKUPSusqmbBuefDX+yUbMBWea2Ob/wdXFyHW8XZqXkprJscysAdKeGWNqlA==


### PR DESCRIPTION
## What changed

Regenerate the `styled-components` descriptor key in `yarn.lock` so it matches the `^6.4.4` range declared in `package.json`. Single-line lockfile change; no dependency versions change (resolved version stays `6.4.4`).

## Why

`yarn install --frozen-lockfile` (used in CI) failed with *"Your lockfile needs to be updated"*. Root cause: commit `35f0734` (styled-components tooling) added `styled-components: ^6.4.4` to `package.json` but wrote the `yarn.lock` entry keyed as `styled-components@^6`. `--frozen-lockfile` requires a lockfile entry keyed by the **exact** declared range, so the mismatch forced an update and failed the run.

## How validated

- `yarn install --frozen-lockfile` → passes ("Already up-to-date")
- `yarn typecheck` → clean
- `yarn lint` → clean
- `yarn test:coverage` → 59 tests pass, 100% coverage

## Remaining risks

None. Diff is a single descriptor-key line; the unrelated working-tree `.gitignore` change was intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)