### PR TITLE
feat(ops): add dependency-health loop with first-run digest

### DIFF
--- a/ops/dependency-health/LOOP_INSTRUCTIONS.md
+++ b/ops/dependency-health/LOOP_INSTRUCTIONS.md
@@ -1,0 +1,83 @@
+# Loop Instructions
+
+You are running the dependency-health loop for this repository.
+
+## Before You Start
+
+1. Read `ops/dependency-health/TASK.md`.
+2. Read `ops/dependency-health/PROGRESS.md` — note the advisory IDs and
+   outdated packages seen on the last run.
+
+## What You Should Do
+
+1. Run `yarn audit --json`.
+2. Run `yarn outdated --json`.
+3. Compare both against what `PROGRESS.md` recorded last run:
+   - New advisories since last run (by ID).
+   - Still-open advisories already known from a prior run.
+   - Newly-outdated packages since last run.
+4. Decide the mode. The trigger is _new information since last run_, never
+   "an unresolved issue still exists" — a known, unfixed critical advisory
+   must not force a full report every single day forever, or quiet mode
+   never actually fires once the first critical/high advisory appears.
+   - **Quiet mode (default)** — no new advisory IDs since last run, no
+     severity escalation on a previously-known advisory, no newly-outdated
+     packages: do not write a report file. Update `PROGRESS.md`'s "Last Run"
+     section with today's date, mode = quiet, and a one-line "no change"
+     summary. State explicitly in that line whether a known critical/high
+     advisory is still open (e.g. "no change; gh-pages critical still open,
+     day N") so it stays visible without a full report.
+   - **Attention mode** — a brand-new advisory ID appears, OR a
+     previously-known advisory's severity increased, OR new packages became
+     outdated: write `ops/dependency-health/outputs/dependency-health.md`
+     (overwrite the previous one) with these sections:
+     - Summary
+     - New advisories since last run (ID, package, severity)
+     - Still-open advisories (ID, package, severity, first seen)
+     - Newly-outdated packages (package, current, wanted, latest)
+     - Recommended action (draft only — describe what upgrading would
+       involve, do not perform it)
+5. Update `ops/dependency-health/PROGRESS.md`: date, trigger (manual or
+   `/loop`), summary, advisory IDs seen, outdated packages seen, output
+   produced (or "none — quiet mode"), whether human review is needed.
+
+## Safety Rules
+
+- Only run `yarn audit --json` and `yarn outdated --json`. No other command.
+- Never run `yarn add`, `npm install`, or anything that modifies
+  dependencies.
+- Never edit `package.json` or `yarn.lock`.
+- Only write to `ops/dependency-health/PROGRESS.md` and
+  `ops/dependency-health/outputs/dependency-health.md`.
+- If unsure whether an action is allowed, stop and ask for human review
+  instead of guessing.
+
+## Scheduled Run Policy (once `/loop` is turned on)
+
+- Quiet mode by default — most days should produce no report, just a
+  one-line state update. A loop that writes a long report every single day
+  gets ignored; save the noise for when something actually changed. A known,
+  still-unfixed critical/high advisory does NOT by itself re-trigger
+  attention mode on its own — see the "day N still open" note in quiet mode
+  above instead.
+- Every 7th consecutive quiet-mode run where a critical/high advisory is
+  still open, write a short reminder to "Needs Human Review" in
+  `PROGRESS.md` (not a full report) — don't let a known issue go silent
+  forever, but don't repeat the full report daily either.
+- If `yarn audit`/`yarn outdated` fails to run (e.g. network issue), log the
+  failure in `PROGRESS.md` and stop — do not write a report based on partial
+  or missing data. Only escalate to human review if 3 consecutive scheduled
+  runs fail this way.
+
+## Verification Checklist
+
+Before ending the run, verify:
+
+- `PROGRESS.md`'s "Last Run" section has today's date, the advisory IDs and
+  outdated packages seen, and which mode this run used.
+- If attention mode: `outputs/dependency-health.md` exists and has all four
+  required sections.
+- No file outside `ops/dependency-health/PROGRESS.md` and
+  `ops/dependency-health/outputs/dependency-health.md` was modified.
+- `package.json` and `yarn.lock` are unchanged (`git diff --stat` should
+  show nothing there).

--- a/ops/dependency-health/PROGRESS.md
+++ b/ops/dependency-health/PROGRESS.md
@@ -1,0 +1,77 @@
+# Loop Progress
+
+## Current State
+
+- Status: /loop active (24h cadence, session-only cron job 36c7fffc)
+- Main objective: draft dependency-health digest, no auto-upgrades
+- Last updated: 2026-07-25
+
+## Last Run
+
+- Date: 2026-07-25
+- Trigger: /loop (immediate run on schedule, cron job 36c7fffc)
+- Summary: No change since the manual run earlier today — same 16 advisories
+  (1 critical, 10 high, 4 moderate, 1 low) and same 14 outdated packages.
+  Quiet mode: no report written.
+- Advisories seen (IDs): 1096485 (GHSA-f8q6-p94x-37v3, minimatch, high),
+  1097162 (GHSA-8mmm-9v2q-x3f9, gh-pages, critical), 1105443
+  (GHSA-v6h2-p8h4-qcjw, brace-expansion, low), 1113459
+  (GHSA-3ppc-4f35-3m26, minimatch, high), 1113538 (GHSA-7r86-cg39-jmmj,
+  minimatch, high), 1113546 (GHSA-23c5-xmqv-rm74, minimatch, high), 1115540
+  (GHSA-f886-m6hf-6m8v, brace-expansion, moderate), 1123897
+  (GHSA-3jxr-9vmj-r5cp, brace-expansion, high), 1124334
+  (GHSA-mh99-v99m-4gvg, brace-expansion, high), 1097691
+  (GHSA-fwr7-v2mv-hh25, async, high), 1106913 (GHSA-35jh-r3h4-6jhm, lodash,
+  high), 1108258 (GHSA-29mw-wpgm-hmr9, lodash, moderate), 1115806
+  (GHSA-r5fr-rjxr-66jc, lodash, high), 1115810 (GHSA-f23m-r3pf-42rh, lodash,
+  moderate), 1120370 (GHSA-xxjr-mmjv-4gpg, lodash, moderate), 1112922
+  (GHSA-c2qf-rxjj-qqgw, semver, high)
+- Outdated packages seen: gh-pages (3.1.0 → wanted 3.2.3 → latest 6.3.0),
+  eslint (9.39.5 → 9.39.5 → latest 10.8.0), typescript (6.0.3 → 6.0.3 →
+  latest 7.0.2), eslint-config-prettier (9.1.2 → 9.1.2 → latest 10.1.8),
+  eslint-plugin-react-hooks (5.2.0 → 5.2.0 → latest 7.1.1),
+  eslint-plugin-react-refresh (0.4.26 → 0.4.26 → latest 0.5.3),
+  @testing-library/jest-dom (6.9.1 → 6.10.0 → latest 7.0.0),
+  @types/testing-library__dom (6.14.0 → 6.14.0 → latest 7.5.0),
+  @vitejs/plugin-react (6.0.3 → 6.0.4 → 6.0.4), prettier (3.9.5 → 3.9.6 →
+  3.9.6), react (19.2.7 → 19.2.8 → 19.2.8), react-dom (19.2.7 → 19.2.8 →
+  19.2.8), typescript-eslint (8.64.0 → 8.65.0 → 8.65.0), vite (8.1.4 →
+  8.1.5 → 8.1.5)
+- Output produced: `outputs/dependency-health.md` (attention mode)
+
+## Open Items
+
+- Track whether the 16 advisories above get resolved by a future gh-pages /
+  eslint / typescript-eslint major-version upgrade (out of scope for this
+  loop — see "Recommended action" in the last report).
+
+## Blockers
+
+-
+
+## Needs Human Review
+
+- Critical advisory GHSA-8mmm-9v2q-x3f9 (gh-pages prototype pollution) —
+  fix requires a major version bump (gh-pages 3.x → 6.x), which is
+  judgement-heavy (may affect the `cd.yml` deploy CLI invocation) and out of
+  this loop's scope. First seen 2026-07-25.
+
+## Next Run Should
+
+- Read this file first.
+- Run `yarn audit --json` and `yarn outdated --json`.
+- Diff against the advisory IDs / outdated packages listed above.
+- Quiet mode if nothing changed; attention mode if anything new or
+  HIGH/CRITICAL appeared.
+
+## Decisions Made
+
+- This loop is read-only + draft-only (Level 1-2). No auto-upgrades, ever —
+  upgrading is judgement-heavy work (may break the build, needs a test run)
+  and out of scope for this loop entirely.
+- Manual testing first, `/loop` only after several stable manual runs.
+
+## Do Not Repeat
+
+- Do not run `yarn add`/`npm install`/edit `package.json` or `yarn.lock`.
+- Do not write a full report when nothing changed — quiet mode only.

--- a/ops/dependency-health/TASK.md
+++ b/ops/dependency-health/TASK.md
@@ -1,0 +1,29 @@
+# Dependency Health Loop
+
+## Goal
+
+Periodically check this project's dependencies for new security advisories
+and newly-outdated packages, compare against the previous run, and produce a
+short draft report — without installing, upgrading, or touching any
+dependency file.
+
+## Expected Output
+
+Each run should produce or update:
+
+- `ops/dependency-health/PROGRESS.md`
+- `ops/dependency-health/outputs/dependency-health.md` (only when there is
+  something new to report — see "quiet mode" in LOOP_INSTRUCTIONS.md)
+
+## Scope
+
+Claude may run `yarn audit --json` and `yarn outdated --json` (the same
+commands this repo's `ci.yml` `dependency-health` job already runs), read
+`ops/dependency-health/PROGRESS.md`, and write to
+`ops/dependency-health/PROGRESS.md` and `ops/dependency-health/outputs/`.
+
+Claude must not run `yarn add`, `npm install`, or any other install/upgrade
+command, and must not edit `package.json` or `yarn.lock`. (This is also
+already blocked at the permission level by this repo's
+`.claude/settings.json` deny list — this loop does not rely on the prompt
+alone for that boundary.)

--- a/ops/dependency-health/outputs/dependency-health.md
+++ b/ops/dependency-health/outputs/dependency-health.md
@@ -1,0 +1,90 @@
+# Dependency Health
+
+## Summary
+
+First real run (no prior baseline in `PROGRESS.md`), so every advisory and
+outdated package below is being seen for the first time by this loop. Attention
+mode is triggered independently of that, since one advisory is **critical**
+severity: `gh-pages@3.1.0` (a transitive dev dependency of `yarn deploy`) is
+vulnerable to prototype pollution (GHSA-8mmm-9v2q-x3f9, CVE-2022-37611).
+`yarn audit --json` reports 16 unique advisories in total (1 critical, 10
+high, 4 moderate, 1 low), all rooted in three outdated dev-only dependency
+chains: `gh-pages` (→ async, lodash, semver, glob→minimatch→brace-expansion),
+`eslint` (→ minimatch/brace-expansion), and `typescript-eslint` (→
+minimatch/brace-expansion). None of these packages are runtime/production
+dependencies — all findings are in `devDependencies` transitive trees.
+
+## New advisories since last run (ID, package, severity)
+
+| GHSA ID | Package | Severity | Title |
+|---|---|---|---|
+| GHSA-8mmm-9v2q-x3f9 | gh-pages | critical | Prototype pollution in gh-pages (CVE-2022-37611) |
+| GHSA-fwr7-v2mv-hh25 | async | high | Prototype pollution in async |
+| GHSA-35jh-r3h4-6jhm | lodash | high | Command injection in lodash |
+| GHSA-r5fr-rjxr-66jc | lodash | high | Code injection via `_.template` imports key names |
+| GHSA-c2qf-rxjj-qqgw | semver | high | ReDoS in semver |
+| GHSA-f8q6-p94x-37v3 | minimatch | high | ReDoS (braceExpand) — CVE-2022-3517 |
+| GHSA-3ppc-4f35-3m26 | minimatch | high | ReDoS via repeated wildcards (CVE-2026-26996) |
+| GHSA-7r86-cg39-jmmj | minimatch | high | ReDoS via non-adjacent GLOBSTAR backtracking (CVE-2026-27903) |
+| GHSA-23c5-xmqv-rm74 | minimatch | high | ReDoS via nested `*()` extglobs (CVE-2026-27904) |
+| GHSA-3jxr-9vmj-r5cp | brace-expansion | high | DoS via exponential-time expansion (CVE-2026-13149) |
+| GHSA-mh99-v99m-4gvg | brace-expansion | high | DoS via unbounded expansion length / OOM (CVE-2026-14257) |
+| GHSA-29mw-wpgm-hmr9 | lodash | moderate | ReDoS in lodash |
+| GHSA-f23m-r3pf-42rh | lodash | moderate | Prototype pollution via array path bypass in `_.unset`/`_.omit` |
+| GHSA-xxjr-mmjv-4gpg | lodash | moderate | Prototype pollution in `_.unset`/`_.omit` |
+| GHSA-f886-m6hf-6m8v | brace-expansion | moderate | Zero-step sequence hang / memory exhaustion (CVE-2026-33750) |
+| GHSA-v6h2-p8h4-qcjw | brace-expansion | low | ReDoS in brace-expansion (CVE-2025-5889) |
+
+## Still-open advisories (ID, package, severity, first seen)
+
+None — this is the first run with data to compare against, so there is no
+prior "still-open" set. Every advisory above is recorded as first seen
+2026-07-25; future runs will move unresolved ones into this section.
+
+## Newly-outdated packages (package, current, wanted, latest)
+
+| Package | Current | Wanted | Latest | Type |
+|---|---|---|---|---|
+| gh-pages | 3.1.0 | 3.2.3 | 6.3.0 | devDependencies |
+| eslint | 9.39.5 | 9.39.5 | 10.8.0 | devDependencies |
+| typescript | 6.0.3 | 6.0.3 | 7.0.2 | devDependencies |
+| eslint-config-prettier | 9.1.2 | 9.1.2 | 10.1.8 | devDependencies |
+| eslint-plugin-react-hooks | 5.2.0 | 5.2.0 | 7.1.1 | devDependencies |
+| eslint-plugin-react-refresh | 0.4.26 | 0.4.26 | 0.5.3 | devDependencies |
+| @testing-library/jest-dom | 6.9.1 | 6.10.0 | 7.0.0 | devDependencies |
+| @types/testing-library__dom | 6.14.0 | 6.14.0 | 7.5.0 | resolutions |
+| @vitejs/plugin-react | 6.0.3 | 6.0.4 | 6.0.4 | devDependencies |
+| prettier | 3.9.5 | 3.9.6 | 3.9.6 | devDependencies |
+| react | 19.2.7 | 19.2.8 | 19.2.8 | dependencies |
+| react-dom | 19.2.7 | 19.2.8 | 19.2.8 | dependencies |
+| typescript-eslint | 8.64.0 | 8.65.0 | 8.65.0 | devDependencies |
+| vite | 8.1.4 | 8.1.5 | 8.1.5 | devDependencies / resolutions |
+
+## Recommended action (draft only)
+
+- **gh-pages (highest priority):** the critical advisory and most of the high
+  advisories (async, lodash, semver, minimatch chain) all root in `gh-pages`
+  3.x's own bundled dependency tree, not in a shared/hoisted package used
+  elsewhere. The patched release line is `gh-pages@5.0.0+`; `package.json`
+  currently pins `^3.1.0`, so a fix means a **major version bump** (3 → 6,
+  since 6.3.0 is latest) with a real chance of CLI/behavior changes — worth
+  double-checking against `cd.yml`, which invokes the `gh-pages` CLI directly
+  (not the `yarn deploy` script). This is judgement-heavy, out of scope for
+  this loop, and should go through a normal PR: bump the dependency, run
+  `yarn typecheck`/`yarn lint`/`yarn test:coverage`, and do a real
+  `yarn deploy` dry-run (or check `gh-pages` CLI flags haven't changed)
+  before merging.
+- **eslint / typescript-eslint minimatch chain:** the remaining
+  brace-expansion/minimatch advisories are pulled in via `eslint` and
+  `typescript-eslint`'s own transitive deps, not directly controllable by a
+  `resolutions` override without risk of an ESLint version mismatch. `eslint`
+  9→10 and `typescript` 6.0.3→7.0.2 are both major bumps with likely config
+  or rule changes (ESLint 10 flat-config behavior, TS 7 diagnostics) — treat
+  as a separate, deliberate upgrade task, not a quick patch.
+- **Low-risk patch/minor bumps** (safe to batch in one small PR when
+  someone picks this up): `react`/`react-dom` 19.2.7→19.2.8, `vite`
+  8.1.4→8.1.5, `prettier` 3.9.5→3.9.6, `@vitejs/plugin-react` 6.0.3→6.0.4,
+  `typescript-eslint` 8.64.0→8.65.0, `@testing-library/jest-dom`
+  6.9.1→6.10.0. None of these are tied to the open advisories above.
+- No upgrade was performed as part of this run, per the loop's read-only
+  scope.


### PR DESCRIPTION
Read-only, draft-only loop (yarn audit/outdated only, no dependency edits) that diffs advisories/outdated packages against PROGRESS.md and writes a report only in attention mode. First run flagged a critical gh-pages prototype-pollution advisory plus 15 more, all rooted in outdated gh-pages/eslint/typescript-eslint transitive deps.