### PR TITLE
docs: fix stale ESLint 9 reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Package manager is **yarn** (see `yarn.lock`). Built on Vite (`vite`, `@vitejs/p
   - Run a single test file: `yarn test src/path/File.test.tsx`
   - CI / single run: `yarn test:run` (or `yarn test:coverage` for coverage)
 - `yarn deploy` — builds then publishes `dist/` to GitHub Pages via `gh-pages` (base path is set via Vite's `base` config in `vite.config.ts`, not a `homepage` field)
-- `yarn lint` — ESLint 9 flat config (`eslint.config.mjs`)
+- `yarn lint` — ESLint 10 flat config (`eslint.config.mjs`)
 - `yarn typecheck` — `tsc --noEmit`
 - `yarn format` — Prettier 3, writing in place
 


### PR DESCRIPTION
eslint was bumped to ^10.8.0 in the dependency-security upgrade (PR #35), but CLAUDE.md's command reference was never updated alongside it. Caught by /harness-review.